### PR TITLE
Adding support for multiple workshops

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ and use of Educates, including user created workshop content for Educates.
 
 The GitHub actions included here are:
 
-* [Publish Workshop](publish-workshop/README.md) - Publishes a workshop to
-  GitHub container registry and creates a release with Kubernetes resource
-  definitions for deploying the workshop as assets.
+* [Publish Workshop](publish-workshop/README.md) - Publishes a workshop or 
+  a collection of Workshops to GitHub container registry and creates a release 
+  with Kubernetes resource definitions for deploying the workshop as assets.
 
 Note that versioning applies to the collection as a whole. This means that if a
 breaking change is made to a single action, then the version is incremented on

--- a/publish-workshop/README.md
+++ b/publish-workshop/README.md
@@ -1,5 +1,4 @@
-Publish Workshop
-================
+# Publish Workshop
 
 This GitHub action supports the following for an Educates workshop:
 
@@ -8,26 +7,22 @@ This GitHub action supports the following for an Educates workshop:
 * Creating a release against the GitHub repository and attach as assets
   Kubernetes resource files for deploying the workshop to Educates.
 
-Note that this GitHub action can only publish a single workshop and will only
-publish an OCI image artefact containing the workshop files. Prior versions of
-this GitHub action could publish multiple workshops and also build custom
-workshop images. Neither of those capabilities are now supported by this GitHub
-action.
+## Support for Multiple Workshops
 
-The GitHub action requires that it be triggered in response to a Git tag being
-applied to the GitHub repository.
+This GitHub action can publish either a single workshop (default) or multiple workshops in one run. The behavior is controlled by the `multiple-workshops` input parameter.
 
-GitHub Workflow
----------------
+- **Single Workshop (default):**
+  - The action publishes a single workshop, with the location of the workshop definition specified by the `workshop-resource-file` input (default: `resources/workshop.yaml`).
+- **Multiple Workshops:**
+  - Set `multiple-workshops: true` and specify the `path` input as the directory containing multiple workshop subdirectories (e.g., `workshops`).
+  - Each subdirectory under the specified path should contain a workshop definition and its resources and 
+  the location of each workshop definition will be specified by the `workshop-resource-file` input (default: `resources/workshop.yaml`) following the `path`.
 
-The name of the GitHub action is:
+---
 
-```
-educates/educates-github-actions/publish-workshop
-```
+## GitHub Workflow Examples
 
-To have an Educates workshop published upon the repository being tagged as
-version `X.Y` use:
+### Single Workshop (default)
 
 ```
 name: Publish Workshop
@@ -51,11 +46,67 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
 ```
 
-Note that version `v6` of this GitHub action produces an exported workshop
-definition which requires Educates 2.6.0 or later.
+### Multiple Workshops
 
-Workshop Definition
--------------------
+```
+name: Publish Workshops
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+"
+
+jobs:
+  publish-workshops:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Publish Workshop
+        uses: educates/educates-github-actions/publish-workshop@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          multiple-workshops: true
+          path: workshops
+```
+
+#### Example Folder Structure for Multiple Workshops
+
+```
+workshops
+├── lab-conda-environment
+│   ├── README.md
+│   ├── resources
+│   │   └── workshop.yaml
+│   └── workshop
+│       └── content
+├── lab-cookie-consent
+│   ├── README.md
+│   ├── resources
+│   │   └── workshop.yaml
+│   └── workshop
+│       ├── content
+│       └── setup.d
+├── lab-docker-runtime
+│   ├── README.md
+│   ├── resources
+│   │   └── workshop.yaml
+│   └── workshop
+│       └── content
+└── lab-examiner-scripts
+    ├── README.md
+    ├── resources
+    │   └── workshop.yaml
+    └── workshop
+        ├── content
+        └── examiner
+```
+
+---
+
+## Workshop Definition
 
 This GitHub action makes use of the `educates publish-workshop` command. As
 such, the workshop definition must include a `spec.publish` section which
@@ -93,15 +144,17 @@ spec:
 
 See the Educates documentation for more information.
 
-Action Configuration
---------------------
+---
 
-Configuration parameters which can be set in the `with` clause for the this
+## Action Configuration
+
+Configuration parameters which can be set in the `with` clause for this
 GitHub action are as follows:
 
 | Name                            | Required | Type     | Description                        |
 |---------------------------------|----------|----------|------------------------------------|
-| `path`                          | False    | String   | Relative directory path under `$GITHUB_WORKSPACE` to workshop files. Defaults to "`.`". |
+| `path`                          | False    | String   | Relative directory path under `$GITHUB_WORKSPACE` to workshop files or to the directory containing multiple workshops. Defaults to "." for single workshop, set to e.g. `workshops` for multiple workshops. |
 | `token`                         | True     | String   | GitHub access token. Must be set to `${{secrets.GITHUB_TOKEN}}` or appropriate personal access token variable reference. |
-| `trainingportal-resource-file`  | False    | String   | Relative path under workshop directory to the `TrainingPortal` resource file. Defaults to "`resources/trainingportal.yaml`". |
-| `workshop-resource-file`        | False    | String   | Relative path under workshop directory to the `Workshop` resource file. Defaults to "`resources/workshop.yaml`". |
+| `trainingportal-resource-file`  | False    | String   | Relative path under workshop directory to the `TrainingPortal` resource file. Defaults to "resources/trainingportal.yaml". |
+| `workshop-resource-file`        | False    | String   | Relative path under workshop directory to the `Workshop` resource file. Defaults to "resources/workshop.yaml". |
+| `multiple-workshops`            | False    | Boolean  | Set to `true` to enable publishing multiple workshops from the directory specified by `path`. |

--- a/publish-workshop/action.yaml
+++ b/publish-workshop/action.yaml
@@ -1,3 +1,4 @@
+cat publish-any-workshop/action.yaml
 name: Workshop Publisher
 description: Publish a single Educates workshop to GitHub Container Registry.
 
@@ -6,9 +7,13 @@ inputs:
     description: "GitHub access token."
     required: true
   path:
-    description: "Relative directory path under $GITHUB_WORKSPACE to workshop files."
+    description: "Relative directory path under $GITHUB_WORKSPACE to workshop files or collection of workshops. (., ./workshops)"
     required: false
     default: '.'
+  multiple-workshops:
+    description: "If true, publish all workshop files in the workshop directory."
+    required: false
+    default: 'false'
   workshop-resource-file:
     description: "Relative path under workshop directory to the Workshop resource file."
     required: false
@@ -29,7 +34,7 @@ runs:
     - name: Install Educates CLI
       shell: bash
       run: |
-        imgpkg pull -i ghcr.io/educates/educates-client-programs:3.2.2 -o /tmp/client-programs
+        imgpkg pull -i ghcr.io/educates/educates-client-programs:3.3.2 -o /tmp/client-programs
         mv /tmp/client-programs/educates-linux-amd64 /usr/local/bin/educates
 
     - name: Calculate release variables
@@ -40,29 +45,49 @@ runs:
         echo "REPOSITORY_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
         echo "REPOSITORY_TAG=${GITHUB_REF##*/}" >>${GITHUB_ENV}
         echo "GITHUB_TOKEN=${{inputs.token}}" >>${GITHUB_ENV}
+        echo "WORKSHOPS_DEST_PATH=${{runner.temp}}/workshops/resources" >>${GITHUB_ENV}
 
-    - name: Publish workshop and create workshop definition
+    - name: Publish workshop content as OCI image and create workshop definition
       shell: bash
       run : |
-        mkdir -p ${{runner.temp}}/workshops/${REPOSITORY_NAME}/resources
-        educates publish-workshop '${{inputs.path}}' \
-          --workshop-file '${{inputs.workshop-resource-file}}' \
-          --export-workshop ${{runner.temp}}/workshops/${REPOSITORY_NAME}/resources/workshop.yaml \
-          --image-repository=ghcr.io/${REPOSITORY_OWNER} \
-          --workshop-version=${REPOSITORY_TAG} \
-          --registry-username=${{github.actor}} \
-          --registry-password=${{env.GITHUB_TOKEN}}
+        mkdir -p ${{env.WORKSHOPS_DEST_PATH}}
+        if [ "${{inputs.multiple-workshops}}" = "false" ]; then
+          educates publish-workshop '${{inputs.path}}' \
+            --workshop-file '${{inputs.workshop-resource-file}}' \
+            --export-workshop ${{env.WORKSHOPS_DEST_PATH}}/workshop.yaml \
+            --image-repository=ghcr.io/${REPOSITORY_OWNER} \
+            --workshop-version=${REPOSITORY_TAG} \
+            --registry-username=${{github.actor}} \
+            --registry-password=${{env.GITHUB_TOKEN}}
+        else
+          for WORKSHOP_NAME in `ls ${{inputs.path}}`; do
+            echo "Publishing workshop: ${WORKSHOP_NAME}"
+            educates publish-workshop "${{inputs.path}}/${WORKSHOP_NAME}" \
+              --export-workshop ${{env.WORKSHOPS_DEST_PATH}}/${WORKSHOP_NAME}.yaml \
+              --image-repository=ghcr.io/${REPOSITORY_OWNER} \
+              --workshop-version=${REPOSITORY_TAG} \
+              --registry-username=${{github.actor}} \
+              --registry-password=${{env.GITHUB_TOKEN}}
+          done
+        fi
 
     - name: Generate archives containing the workshop definition
       shell: bash
       run: |
-        (cd ${{runner.temp}}; tar cvfz workshops.tar.gz workshops)
-        (cd ${{runner.temp}}; zip workshops.zip -r workshops)
+        ytt -f ${{env.WORKSHOPS_DEST_PATH}} > ${{runner.temp}}/workshops.yaml
+        (cd ${{runner.temp}}; tar cvfz workshops.tar.gz workshops.yaml)
+        (cd ${{runner.temp}}; zip workshops.zip workshops.yaml)
 
     - uses: actions/upload-artifact@v4
       with:
-        name: workshop.yaml
-        path: ${{runner.temp}}/workshops/${{env.REPOSITORY_NAME}}/resources/workshop.yaml
+        name: workshops.yaml
+        path: ${{runner.temp}}/workshops.yaml
+
+    - uses: actions/upload-artifact@v4
+      if: inputs.multiple-workshops == 'true'
+      with:
+        name: workshops
+        path: ${{env.WORKSHOPS_DEST_PATH}}/*.yaml
 
     - uses: actions/upload-artifact@v4
       with:
@@ -89,5 +114,7 @@ runs:
         files: |
           ${{runner.temp}}/workshops.tar.gz
           ${{runner.temp}}/workshops.zip
-          ${{runner.temp}}/workshops/${{env.REPOSITORY_NAME}}/resources/workshop.yaml
+          ${{runner.temp}}/workshop.yaml
+          ${{runner.temp}}/workshops.yaml
           ${{inputs.path}}/${{inputs.trainingportal-resource-file}}
+          ${{env.WORKSHOPS_DEST_PATH}}/*.yaml


### PR DESCRIPTION
Support for publishing multiple workshops is added to the single publish-workshop action.

There's now an attribute `multiple-workshops` that when `true` will look for folders under `path` attribute` which typically will be `workshops` and publish every workshop definition with the workshop/folder as file name.

The .zip and .tar.gz now contains a single workshops.yaml file with the one single definition or multiple definitions in it. The directory structure inside these archives have now changed to be flat, which could potentially be a breaking change, although probably no one uses these archives for anything. (**NOTE**: I would personally consider the value of these archives and potentially remove them from release artifacts)

README has been updated.