### PR TITLE
Action for deploying multiple workshops

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ The GitHub actions included here are:
   GitHub container registry and creates a release with Kubernetes resource
   definitions for deploying the workshop as assets.
 
+* [Publish Multiple Workshop](publish-multiple-workshops/README.md) - Publishes 
+  a collection of workshop to GitHub container registry and creates a release 
+  with Kubernetes resource definitions for deploying the workshops as assets.
+
 Note that versioning applies to the collection as a whole. This means that if a
 breaking change is made to a single action, then the version is incremented on
 all actions, even though changes may not have been made to the other actions.

--- a/publish-multiple-workshops/README.md
+++ b/publish-multiple-workshops/README.md
@@ -1,0 +1,144 @@
+Publish Multiple Workshops
+==========================
+
+This GitHub action supports the following for a collection of Educates workshops:
+
+* For each workshop:
+  * Creating an OCI image artefact containing workshop content files and pushing
+    it to the GitHub container registry.
+* Creating a release against the GitHub repository and attach as assets
+  Kubernetes resource files for deploying the collection of workshop to Educates.
+
+Note that this GitHub action can publish multilpe workshops and will publish, 
+for each workshop, an OCI image artefact containing the workshop files. 
+
+The GitHub action requires that it be triggered in response to a Git tag being
+applied to the GitHub repository.
+
+GitHub Workflow
+---------------
+
+The name of the GitHub action is:
+
+```
+educates/educates-github-actions/publish-multiple-workshops
+```
+
+To have a collection of Educates workshops published upon the repository being tagged as
+version `X.Y` use:
+
+```
+name: Publish Collection of Workshops
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+"
+
+jobs:
+  publish-workshop:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Create release
+        uses: educates/educates-github-actions/publish-multiple-workshops@v7
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+```
+
+Note that version `v7` and later of this GitHub action produces an exported workshop
+definition which requires Educates 2.6.0 or later.
+
+Workshop Definition
+-------------------
+
+This GitHub action makes use of the `educates publish-workshop` command. As
+such, the workshop definition must include a `spec.publish` section which
+defines where the image is to be published:
+
+```
+apiVersion: training.educates.dev/v1beta1
+kind: Workshop
+metadata:
+  name: {name}
+spec:
+  publish:
+    image: $(image_repository)/{name}-files:$(workshop_version)
+```
+
+The workshop definition may optionally specify what files should be included in
+the OCI image artefact for the workshop.
+
+```
+apiVersion: training.educates.dev/v1beta1
+kind: Workshop
+metadata:
+  name: {name}
+spec:
+  publish:
+    image: $(image_repository)/{name}-files:$(workshop_version)
+    files:
+    - directory:
+        path: .
+      includePaths:
+      - /workshop/**
+      - /templates/**
+      - /README.md
+```
+
+See the Educates documentation for more information.
+
+Collection of workshops directory structure
+-------------------------------------------
+This action assumes that a collection of workshops will have the `recommended` folder structure,
+and every workshop in the collection `must` have the same workshop structure. 
+
+This is an example of the recommended structure:
+
+```
+resources
+├── trainingportal.yaml
+workshops
+├── lab-conda-environment
+│   ├── README.md
+│   ├── resources
+│   │   └── workshop.yaml
+│   └── workshop
+│       └── content
+├── lab-cookie-consent
+│   ├── README.md
+│   ├── resources
+│   │   └── workshop.yaml
+│   └── workshop
+│       ├── content
+│       └── setup.d
+├── lab-docker-runtime
+│   ├── README.md
+│   ├── resources
+│   │   └── workshop.yaml
+│   └── workshop
+│       └── content
+└── lab-examiner-scripts
+    ├── README.md
+    ├── resources
+    │   └── workshop.yaml
+    └── workshop
+        ├── content
+        └── examiner
+```
+
+Action Configuration
+--------------------
+
+Configuration parameters which can be set in the `with` clause for the this
+GitHub action are as follows:
+
+| Name                            | Required | Type     | Description                        |
+|---------------------------------|----------|----------|------------------------------------|
+| `path`                          | False    | String   | Relative directory path under `$GITHUB_WORKSPACE` to the collection of workshops. Defaults to "`workshops`". |
+| `token`                         | True     | String   | GitHub access token. Must be set to `${{secrets.GITHUB_TOKEN}}` or appropriate personal access token variable reference. |
+| `trainingportal-resource-file`  | False    | String   | Relative path under `$GITHUB_WORKSPACE` to the `TrainingPortal` resource file. Defaults to "`resources/trainingportal.yaml`". |
+| `workshop-resource-file`        | False    | String   | Relative path under workshop directory to the `Workshop` resource file. Defaults to "`resources/workshop.yaml`". Every workshop must have same directory structure. |

--- a/publish-multiple-workshops/action.yaml
+++ b/publish-multiple-workshops/action.yaml
@@ -1,0 +1,109 @@
+name: Multiple Workshops Publisher
+description: Publish a collection of Educates workshops to GitHub Container Registry.
+
+inputs:
+  token:
+    description: "GitHub access token."
+    required: true
+  path:
+    description: "Relative directory path under $GITHUB_WORKSPACE to the collection of workshops."
+    required: false
+    default: 'workshops'
+  workshop-resource-file:
+    description: "Relative path under workshop directory to the workshops resource file. All workshops must have same directory structure."
+    required: false
+    default: 'resources/workshop.yaml'
+  trainingportal-resource-file:
+    description: "Relative path under $GITHUB_WORKSPACE directory to the TrainingPortal resource file."
+    required: false
+    default: 'resources/trainingportal.yaml'
+
+permissions:
+  contents: read
+  packages: write
+
+runs:
+  using: composite
+
+  steps:
+    - name: Install Carvel tools
+      shell: bash
+      run: curl -L https://carvel.dev/install.sh | bash
+
+    - name: Install Educates CLI
+      shell: bash
+      run: |
+        imgpkg pull -i ghcr.io/educates/educates-client-programs:3.3.2 -o /tmp/client-programs
+        mv /tmp/client-programs/educates-linux-amd64 /usr/local/bin/educates
+
+    - name: Calculate release variables
+      shell: bash
+      run: |
+        REPOSITORY_NAME=${{github.event.repository.name}}
+        echo "REPOSITORY_NAME=${REPOSITORY_NAME,,}" >>${GITHUB_ENV}
+        echo "REPOSITORY_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
+        echo "REPOSITORY_TAG=${GITHUB_REF##*/}" >>${GITHUB_ENV}
+        echo "GITHUB_TOKEN=${{inputs.token}}" >>${GITHUB_ENV}
+
+    - name: Publish workshop content as OCI image and create workshop definition
+      shell: bash
+      run : |
+        mkdir -p ${{runner.temp}}/release
+        for WORKSHOP_NAME in `ls ${{inputs.path}}`; do
+          mkdir -p ${{runner.temp}}/workshops/${WORKSHOP_NAME}/resources
+          echo "Publishing workshop: ${WORKSHOP_NAME}"
+          educates publish-workshop ${{inputs.path}}/${WORKSHOP_NAME} \
+            --export-workshop ${{runner.temp}}/workshops/${WORKSHOP_NAME}/resources/workshop.yaml \
+            --image-repository=ghcr.io/${{env.REPOSITORY_OWNER}} \
+            --workshop-version=${{env.REPOSITORY_TAG}} \
+            --registry-username=${{github.actor}} \
+            --registry-password=${{env.GITHUB_TOKEN}}
+          echo "Make a releasable copy of the workshop definition"
+          cp ${{runner.temp}}/workshops/${WORKSHOP_NAME}/resources/workshop.yaml ${{runner.temp}}/release/${WORKSHOP_NAME}.yaml
+        done
+
+    - name: Generate archives containing the workshop definition
+      shell: bash
+      run: |
+        ytt -f ${{runner.temp}}/workshops > ${{runner.temp}}/workshops.yaml
+        (cd ${{runner.temp}}; tar cvfz workshops.tar.gz workshops)
+        (cd ${{runner.temp}}; zip workshops.zip -r workshops)
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: individual-workshops
+        path: ${{runner.temp}}/release/*.yaml
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: workshops.yaml
+        path: ${{runner.temp}}/workshops.yaml
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: workshops.tar.gz
+        path: ${{runner.temp}}/workshops.tar.gz
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: workshops.zip
+        path: ${{runner.temp}}/workshops.zip
+
+    - name: Create the GitHub release for the workshop
+      id: create_release
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: softprops/action-gh-release@v2
+      env:
+        GITHUB_TOKEN: ${{env.GITHUB_TOKEN}}
+      with:
+        tag_name: ${{env.REPOSITORY_TAG}}
+        name: "${{env.REPOSITORY_NAME}}:${{env.REPOSITORY_TAG}}"
+        draft: false
+        prerelease: false
+        fail_on_unmatched_files: false
+        files: |
+          ${{runner.temp}}/workshops.tar.gz
+          ${{runner.temp}}/workshops.zip
+          ${{runner.temp}}/workshops.yaml
+          ${{inputs.path}}/${{inputs.trainingportal-resource-file}}
+          ${{runner.temp}}/release/*.yaml

--- a/publish-workshop/README.md
+++ b/publish-workshop/README.md
@@ -46,12 +46,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Create release
-        uses: educates/educates-github-actions/publish-workshop@v6
+        uses: educates/educates-github-actions/publish-workshop@v7
         with:
           token: ${{secrets.GITHUB_TOKEN}}
 ```
 
-Note that version `v6` of this GitHub action produces an exported workshop
+Note that version `v6` and later of this GitHub action produces an exported workshop
 definition which requires Educates 2.6.0 or later.
 
 Workshop Definition

--- a/publish-workshop/action.yaml
+++ b/publish-workshop/action.yaml
@@ -29,7 +29,7 @@ runs:
     - name: Install Educates CLI
       shell: bash
       run: |
-        imgpkg pull -i ghcr.io/educates/educates-client-programs:3.2.2 -o /tmp/client-programs
+        imgpkg pull -i ghcr.io/educates/educates-client-programs:3.3.2 -o /tmp/client-programs
         mv /tmp/client-programs/educates-linux-amd64 /usr/local/bin/educates
 
     - name: Calculate release variables


### PR DESCRIPTION
This PR adds support for deploying multiple workshops. It follows the single workshop conventions and uses same configuration inputs, also generates same outputs except there's an artifact with all the individual workshop yaml files with the workshop name as name of the file, as well as when releasing, these are also part of the release.
Structure of zip and .tar.gz files are still the same. The collection of workshops are published under a single `workshops.yaml` file, instead of `workshop.yaml` which is when using the single workshop action.